### PR TITLE
Check for correct pathname on construction

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@
 const request = require('request').defaults({ jar: true });
 const _ = require('lodash');
 const moment = require('moment');
+const url = require('url');
 
 let apiHost;
 let sessionId;
@@ -22,7 +23,19 @@ class Ayuda {
 
   // Login required for Ayuda's API
   constructor(auth) {
-    apiHost = auth.apiUrl;
+
+    const juicePath = '/Juice/pi';
+
+      if (url.parse(auth.apiUrl).pathname !== juicePath) {
+
+          apiHost = url.resolve(auth.apiUrl, juicePath);
+
+      } else {
+
+          apiHost = auth.apiUrl;
+
+      }
+
     username = auth.username;
     password = auth.password;
     sessionId = '';
@@ -82,7 +95,7 @@ class Ayuda {
     // else if (!(dayDate instanceof Date)) return cb(new Error('Needs to be a Date object'));
 
     const start = moment.utc(dayDate).startOf('day');
-    var end = moment(start.toDate());
+    const end = moment(start.toDate());
     end.add(1, 'day');
 
     const extraOpts = {
@@ -186,6 +199,10 @@ class Ayuda {
 
       return cb(err, body)
     });
+  }
+
+  getUrl(){
+    return apiHost;
   }
 
 } // class : Ayuda

--- a/test/ayuda.test.js
+++ b/test/ayuda.test.js
@@ -2,12 +2,6 @@ const Ayuda = require('../index.js');
 const expect = require('chai').expect;
 const nock = require('nock');
 
-/*
-    TODO: add switch that performs test on actual ayuda service
-    TODO: should makeRequest throw errors?
-    TODO: should we add mock functionality into the module itself? (could be useful for app testing)
- */
-
 describe('Ayuda', function() {
 
     let ayuda;
@@ -18,11 +12,34 @@ describe('Ayuda', function() {
         userInfo = {
             username: process.env.AY_API_USER || 'test',
             password: process.env.AY_API_PASSWORD || 'testPass',
-            apiUrl: process.env.AY_API_URL || 'https://pv.ayudapreview.com/Juice/pi'
+            apiUrl: process.env.AY_API_URL || 'https://test.ayudapreview.com/Juice/pi'
         };
 
         ayuda = new Ayuda(userInfo);
 
+    });
+
+    describe('#constructor', function(){
+
+        it('should handle complete urls', function(done){
+
+            const session = new Ayuda(userInfo);
+            expect(session.getUrl()).to.equal(userInfo.apiUrl);
+            done();
+        });
+
+        it('should handle incomplete urls', function(done){
+
+            const sameInfoIncompleteUrl = {
+                username: process.env.AY_API_USER || 'test',
+                password: process.env.AY_API_PASSWORD || 'testPass',
+                apiUrl: process.env.AY_API_URL || 'https://test.ayudapreview.com'
+            };
+
+            const session = new Ayuda(sameInfoIncompleteUrl);
+            expect(session.getUrl()).to.equal(userInfo.apiUrl);
+            done();
+        });
     });
 
     // makeRequest should handle errors and successful requests appropriately
@@ -176,53 +193,22 @@ describe('Ayuda', function() {
 
     });
 
-
-    describe('#flattenPlaylog()', function(){
-
-        let dummyLogs;
-
-        before(function(){
-
-            let start = moment(new Date());
-            let end = moment(new Date()).add(1, 'hour');
-
-            let Face = Ayuda.Mock.Face;
-            let campaign = new Face();
-
-            campaign.createAds( 3 );
-            campaign.generateLoop(start, end);
-
-            dummyLogs = campaign.getDigitalPlayLogs();
-
-        });
-
-    });
-
-
     describe('#setPlayer()', function(){
-
         it('should set player id in object', function(done){
-
             ayuda.setPlayerId('f75c62da-4086-4e4a-9dc5-e0e8c56ca69a');
             done();
         });
-
     });
 
     describe('#setDigitalFaceCode()', function(){
-
         it('should set digitalfacecode', function(done){
-
             ayuda.setDigitalFaceCode('');
             done();
-
         });
-
     });
 
     describe('#getTimeZone()',function(){
         it('should get timezone data from player', function(done){
-
             let fakeAyudaLogin = nock(userInfo.apiUrl)
                 .post('/Player/Get')
                 .reply(200, {
@@ -241,6 +227,7 @@ describe('Ayuda', function() {
 
         });
     });
+
 
 });
 


### PR DESCRIPTION
Allow urls such as `https://someGroup.ayudapreview.com/` to be used instead of just `https://someGroup.ayudapreview.com/juice/pi` 